### PR TITLE
Feature: global_state_test 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
+name = "rust_decimal"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f5b8840fb1f83869a3e1dfd06d93db79ea05311ac5b42b8337d3371caa4f1"
+dependencies = [
+ "arrayvec 0.5.2",
+ "num-traits 0.2.14",
+ "serde 1.0.125",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-hex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1373,7 @@ dependencies = [
  "rand 0.8.3",
  "rayon",
  "regex",
+ "rust_decimal",
  "serde 1.0.125",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ff = {package="ff_ce" , version="0.11", features = ["derive"]}
 babyjubjub-rs = { version = "0.0.8"}
 hex = "0.4.3"
 arrayref = "0.3.6"
+rust_decimal = { version = "1.10.3", features = ["serde_json"] }
 
 [[bin]]
 name = "state_keeper"

--- a/src/bin/global_state_test.rs
+++ b/src/bin/global_state_test.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Lines, Write};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 enum WrappedMessage {
     BALANCE(messages::BalanceMessage),
@@ -555,8 +556,13 @@ fn export_circuit_and_testdata(
 fn test_all() -> Result<()> {
     let circuit_repo = fs::canonicalize(PathBuf::from("../circuits")).expect("invalid circuits repo path");
 
+    let timing = Instant::now();
     let (blocks, components) = replay_msgs(&circuit_repo)?;
-    println!("genesis {} blocks", blocks.len());
+    println!(
+        "genesis {} blocks (TPS: {})",
+        blocks.len(),
+        (test_const::NTXS * blocks.len()) as f32 / timing.elapsed().as_secs_f32()
+    );
 
     let circuit_dir = export_circuit_and_testdata(&circuit_repo, blocks, components)?;
 

--- a/src/bin/global_state_test.rs
+++ b/src/bin/global_state_test.rs
@@ -1,0 +1,510 @@
+use state_keeper::circuit_test::{self, messages, types};
+use state_keeper::state::{common, global_state};
+use anyhow::{Result, anyhow};
+use serde_json::{Value};
+use ff::Field;
+use rust_decimal::Decimal;
+//use std::cmp;
+use std::fs;
+use std::fs::File;
+use std::io::{Write, BufRead, BufReader, Lines};
+use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+
+enum WrappedMessage {
+    BALANCE(messages::BalanceMessage),
+    TRADE(messages::TradeMessage),
+    ORDER(messages::OrderMessage),
+}
+
+fn parse_msg(line: String) -> Result<WrappedMessage> {
+    let v: Value = serde_json::from_str(&line)?;
+    if let Value::String(typestr) = &v["type"] {
+
+        let val = v["value"].clone();
+
+        match typestr.as_str() {
+        "BalanceMessage" => {
+            let data = serde_json::from_value(val).map_err(|e| anyhow!("wrong balance: {}", e))?;
+            Ok(WrappedMessage::BALANCE(data))
+        },
+        "OrderMessage" => {
+            let data = serde_json::from_value(val).map_err(|e| anyhow!("wrong balance: {}", e))?;
+            Ok(WrappedMessage::ORDER(data))
+        },
+        "TradeMessage" => {
+            let data = serde_json::from_value(val).map_err(|e| anyhow!("wrong balance: {}", e))?;
+            Ok(WrappedMessage::TRADE(data))
+        },
+        other => Err(anyhow!("unrecognized type field {}", other))
+        }
+
+    }else {
+        Err(anyhow!("missed or unexpected type field: {}", line))
+    }
+}
+
+type PlaceOrderType = HashMap<u64, (u32, u64)>;
+//index type?
+#[derive(Debug)]
+struct PlaceOrder (PlaceOrderType);
+
+impl AsRef<PlaceOrderType> for PlaceOrder {
+    fn as_ref(&self) -> &PlaceOrderType {
+        return &self.0;
+    }
+}
+
+impl AsMut<PlaceOrderType> for PlaceOrder {
+    fn as_mut(&mut self) -> &mut PlaceOrderType {
+        return &mut self.0;
+    }
+}
+
+
+mod test_const {
+
+    pub const NTXS : usize = 2;
+    pub const BALANCELEVELS : usize = 2;
+    pub const ORDERLEVELS : usize = 7;
+    pub const ACCOUNTLEVELS : usize = 2;
+    pub const MAXORDERNUM : usize  = 2usize.pow(ORDERLEVELS as u32);
+    pub const MAXACCOUNTNUM : usize = 2usize.pow(ACCOUNTLEVELS as u32);
+    pub const MAXTOKENNUM : usize = 2usize.pow(BALANCELEVELS as u32);
+    pub const VERBOSE : bool = true;
+
+    pub fn token_id(token_name: &str) -> u32 {
+        match token_name {
+            "ETH" => 0,
+            "USDT" => 1,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn prec(token_id:u32) -> u32 {
+        match token_id {
+            0 | 1 => 6,
+            _ => unreachable!(),
+        }
+    }
+
+}
+
+#[derive(Clone, Copy)]
+struct TokenIDPair (u32, u32);
+/*
+impl TokenIDPair {
+    fn swap(&mut self) {
+        let tmp = self.1;
+        self.1 = self.0;
+        self.0 = tmp;
+    }
+}
+*/
+#[derive(Clone, Copy)]
+struct TokenPair<'c> (&'c str, &'c str);
+
+struct OrderState<'c> {
+    origin: &'c messages::VerboseOrderState,
+    //seems not used yet
+    status: u32, 
+    side: &'static str,
+    token_sell: u32,
+    token_buy: u32,
+    total_sell: Decimal,
+    total_buy: Decimal,
+    filled_sell: Decimal,
+    filled_buy: Decimal,
+}
+
+struct OrderStateTag {
+    id: u64,
+    account_id: u32,
+    role: messages::MarketRole,
+}
+
+impl<'c> From<&'c str> for TokenPair<'c> {
+    fn from(origin : &'c str) -> Self {
+        let mut assets = origin.split('_');
+        let asset_1 = assets.next().unwrap();
+        let asset_2 = assets.next().unwrap();
+        TokenPair(asset_1, asset_2)
+    }
+}
+
+impl<'c> From<TokenPair<'c>> for TokenIDPair {
+    fn from(origin : TokenPair<'c>) -> Self {
+        TokenIDPair(test_const::token_id(origin.0),
+            test_const::token_id(origin.1))
+    }
+}
+
+impl<'c> OrderState<'c> {
+    fn parse(origin : &'c messages::VerboseOrderState, id_pair : TokenIDPair, 
+        token_pair : TokenPair<'c>, side : &'static str) -> Self {
+        match side {
+            "ASK" => OrderState {
+                origin, side,
+                status: 0,
+                token_sell: id_pair.0,
+                token_buy: id_pair.1,
+                total_sell: origin.amount,
+                total_buy: origin.amount * origin.price,
+                filled_sell: origin.finished_base,
+                filled_buy: origin.finished_quote,
+            },
+            "BID" => OrderState {
+                origin, side,
+                status: 0,
+                token_sell: id_pair.1,
+                token_buy: id_pair.0,
+                total_sell: origin.amount * origin.price,
+                total_buy: origin.amount ,
+                filled_sell: origin.finished_quote,
+                filled_buy: origin.finished_base,            
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'c> From<OrderState<'c>> for common::Order {
+    fn from(origin : OrderState<'c>) -> Self {
+        common::Order {
+            status: types::u32_to_fr(origin.status),
+            tokenbuy: types::u32_to_fr(origin.token_buy),
+            tokensell: types::u32_to_fr(origin.token_sell),
+            filled_sell: types::number_to_integer(&origin.filled_sell, test_const::prec(origin.token_sell)),
+            filled_buy: types::number_to_integer(&origin.filled_buy, test_const::prec(origin.token_buy)),
+            total_sell: types::number_to_integer(&origin.total_sell, test_const::prec(origin.token_sell)),
+            total_buy: types::number_to_integer(&origin.total_buy, test_const::prec(origin.token_buy)),
+        }     
+    }
+}
+
+impl OrderState<'_> {
+    fn tag(self, trade: &messages::TradeMessage) -> (Self, OrderStateTag) {
+        match self.side {
+            "ASK" => (self, OrderStateTag{
+                id: trade.ask_order_id,
+                account_id: trade.ask_user_id,
+                role: trade.ask_role,
+            }),
+            "BID" => (self, OrderStateTag{
+                id: trade.bid_order_id,
+                account_id: trade.bid_user_id,
+                role: trade.bid_role,
+            }),
+            _ => unreachable!(),
+        }
+    }
+}
+
+struct OrderStateWithTag<'c> (OrderState<'c>, OrderStateTag);
+
+impl<'c> From<(OrderState<'c>, OrderStateTag)> for OrderStateWithTag<'c> {
+    fn from(origin: (OrderState<'c>, OrderStateTag)) -> Self {
+        Self(origin.0, origin.1)
+    }
+}
+
+impl<'c> std::cmp::PartialOrd for OrderStateWithTag<'c> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'c> std::cmp::PartialEq for OrderStateWithTag<'c> {
+    fn eq(&self, other: &Self) -> bool {
+        self.tag_id() == other.tag_id()
+    }
+}
+
+impl<'c> std::cmp::Eq for OrderStateWithTag<'c> {}
+
+impl<'c> std::cmp::Ord for OrderStateWithTag<'c> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.tag_id().cmp(&other.tag_id())
+    }
+}
+
+impl OrderStateWithTag<'_> {
+
+    fn tag_id(&self) -> u64 {
+        self.1.id
+    }
+
+    fn account_id(&self) -> u32 {
+        self.1.account_id
+    }
+
+    fn place_order_tx(&self) -> common::PlaceOrderTx {
+
+        let order = &self.0;
+        let tag = &self.1;
+
+        common::PlaceOrderTx {
+            account_id: tag.account_id,
+            previous_token_id_sell: 0,
+            previous_token_id_buy: 0,
+            previous_amount_sell: types::Fr::zero(),
+            previous_amount_buy: types::Fr::zero(),
+            previous_filled_sell: types::Fr::zero(),
+            previous_filled_buy: types::Fr::zero(),
+            token_id_sell: order.token_sell,
+            token_id_buy: order.token_buy,
+            amount_sell: types::number_to_integer(&order.total_sell, test_const::prec(order.token_sell)),
+            amount_buy: types::number_to_integer(&order.total_buy, test_const::prec(order.token_buy)),            
+        }
+    }
+}
+
+#[derive(PartialEq, Debug)]
+struct CommonBalanceState {
+    bid_user_base: types::Fr,
+    bid_user_quote: types::Fr,
+    ask_user_base: types::Fr,
+    ask_user_quote: types::Fr,
+}
+
+impl CommonBalanceState {
+    fn parse(origin : &messages::VerboseBalanceState, id_pair : TokenIDPair) -> Self {
+
+        let base_id = id_pair.0;
+        let quote_id = id_pair.1;
+
+        CommonBalanceState {
+            bid_user_base: types::number_to_integer(&origin.bid_user_base, test_const::prec(base_id)),
+            bid_user_quote: types::number_to_integer(&origin.bid_user_quote, test_const::prec(quote_id)),
+            ask_user_base: types::number_to_integer(&origin.ask_user_base, test_const::prec(base_id)),
+            ask_user_quote: types::number_to_integer(&origin.ask_user_quote, test_const::prec(quote_id)),
+        }
+    }
+    
+    fn build_local(state :&global_state::GlobalState, bid_id : u32, ask_id: u32, id_pair : TokenIDPair) -> Self {
+        let base_id = id_pair.0;
+        let quote_id = id_pair.1;    
+        
+        CommonBalanceState {
+            bid_user_base: state.get_token_balance(bid_id, base_id),
+            bid_user_quote: state.get_token_balance(bid_id, quote_id),
+            ask_user_base: state.get_token_balance(ask_id, base_id),
+            ask_user_quote: state.get_token_balance(ask_id, quote_id),
+        }        
+    }
+}
+
+fn assert_balance_state(balance_state: &messages::VerboseBalanceState, 
+    state : &global_state::GlobalState, bid_id : u32, ask_id : u32, id_pair : TokenIDPair, ) {
+    
+    let local_balance = CommonBalanceState::build_local(state, bid_id, ask_id, id_pair);
+    let parsed_state = CommonBalanceState::parse(balance_state, id_pair);
+    assert_eq!(local_balance, parsed_state);
+}
+
+impl PlaceOrder {
+
+    fn assert_order_state<'c>(&self, state : &global_state::GlobalState, 
+        ask_order_state : OrderStateWithTag<'c>, 
+        bid_order_state : OrderStateWithTag<'c>){
+
+        let ask_order_local = state.get_account_order(ask_order_state.account_id(), 
+            self.as_ref().get(&ask_order_state.tag_id()).unwrap().1 as u32);
+        assert_eq!(ask_order_local, common::Order::from(ask_order_state.0));
+
+        let bid_order_local = state.get_account_order(bid_order_state.account_id(), 
+            self.as_ref().get(&bid_order_state.tag_id()).unwrap().1 as u32);
+        assert_eq!(bid_order_local, common::Order::from(bid_order_state.0));
+
+    }
+
+
+    fn trade_into_spot_tx(&self, trade : &messages::TradeMessage) -> common::SpotTradeTx {
+        //allow information can be obtained from trade
+        let id_pair = TokenIDPair::from(TokenPair::from(trade.market.as_str()));
+    
+        match trade.ask_role {
+            messages::MarketRole::MAKER => common::SpotTradeTx {
+                order1_account_id: trade.ask_user_id,
+                order2_account_id: trade.bid_user_id,
+                token_id_1to2: id_pair.0,
+                token_id_2to1: id_pair.1,
+                amount_1to2: types::number_to_integer(&trade.amount, test_const::prec(id_pair.0)),
+                amount_2to1: types::number_to_integer(&trade.quote_amount, test_const::prec(id_pair.1)),
+                order1_id: self.as_ref().get(&trade.ask_order_id).unwrap().1 as u32,
+                order2_id: self.as_ref().get(&trade.bid_order_id).unwrap().1 as u32,
+            },
+            messages::MarketRole::TAKER => common::SpotTradeTx {
+                order1_account_id: trade.bid_user_id,
+                order2_account_id: trade.ask_user_id,
+                token_id_1to2: id_pair.1,
+                token_id_2to1: id_pair.0,
+                amount_1to2: types::number_to_integer(&trade.quote_amount, test_const::prec(id_pair.1)),
+                amount_2to1: types::number_to_integer(&trade.amount, test_const::prec(id_pair.0)),
+                order1_id: self.as_ref().get(&trade.bid_order_id).unwrap().1 as u32,
+                order2_id: self.as_ref().get(&trade.ask_order_id).unwrap().1 as u32,
+            },
+        }
+    }
+
+    fn handle_trade(&mut self, state : &mut global_state::GlobalState, trade: messages::TradeMessage){
+
+        let token_pair = TokenPair::from(trade.market.as_str());
+        let id_pair = TokenIDPair::from(token_pair);
+
+        let ask_order_state_before : OrderStateWithTag = OrderState::parse(
+            &trade.state_before.ask_order_state, id_pair, token_pair, "ASK",
+        ).tag(&trade).into();
+
+        let bid_order_state_before : OrderStateWithTag = OrderState::parse(
+            &trade.state_before.bid_order_state, id_pair, token_pair, "BID",
+        ).tag(&trade).into();
+
+        //this field is not used yet ...
+        let ask_order_state_after : OrderStateWithTag = OrderState::parse(
+            &trade.state_after.ask_order_state, id_pair, token_pair, "ASK",
+        ).tag(&trade).into();
+        
+        let bid_order_state_after : OrderStateWithTag = OrderState::parse(
+            &trade.state_after.bid_order_state, id_pair, token_pair, "BID",
+        ).tag(&trade).into();        
+
+        //seems we do not need to use map/zip liket the ts code because the suitable order_id has been embedded
+        //into the tag.id field
+        let mut put_states = vec![&ask_order_state_before, &bid_order_state_before];
+        put_states.sort();
+
+        for order_state in put_states.into_iter() {
+            if !self.as_ref().contains_key(&order_state.tag_id()){
+                //why the returning order id is u32?
+                let new_order_id = state.place_order(order_state.place_order_tx());
+                self.as_mut().insert(order_state.tag_id(), (order_state.account_id(), new_order_id as u64));
+                if test_const::VERBOSE {
+                    println!("global order id {} to user order id ({},{})", 
+                        order_state.tag_id(), order_state.account_id(), new_order_id);
+                }
+            }else if test_const::VERBOSE {
+                println!("skip put order {}",order_state.tag_id() );
+            }
+        }
+
+        assert_balance_state(&trade.state_before.balance, state, 
+            bid_order_state_before.account_id(),
+            ask_order_state_before.account_id(),
+            id_pair);
+        self.assert_order_state(state, ask_order_state_before, bid_order_state_before);
+
+        state.spot_trade(self.trade_into_spot_tx(&trade));
+
+        assert_balance_state(&trade.state_after.balance, state, 
+            bid_order_state_after.account_id(),
+            ask_order_state_after.account_id(),
+            id_pair);
+        self.assert_order_state(state, ask_order_state_after, bid_order_state_after);
+
+        println!("trade {} test done", trade.id);
+    }    
+
+}
+
+fn handle_deposit(state : &mut global_state::GlobalState, deposit : messages::BalanceMessage) {
+    //integrate the sanity check here ...
+    assert!(!deposit.change.is_sign_negative(), "only support deposit now");    
+
+    let token_id = test_const::token_id(&deposit.asset);
+
+    let balance_before = deposit.balance - deposit.change;
+    assert!(!balance_before.is_sign_negative(), "invalid balance {:?}", deposit);
+
+    let expected_balance_before = state.get_token_balance(deposit.user_id, token_id);
+    assert_eq!(expected_balance_before, 
+        types::number_to_integer(&balance_before, test_const::prec(token_id)));
+    
+    state.deposit_to_old(
+        common::DepositToOldTx { token_id,
+            account_id: deposit.user_id,
+            amount: types::number_to_integer(&deposit.change, test_const::prec(token_id)),
+        }
+    );
+}
+
+
+fn replay_msgs(test_dir : &PathBuf) -> Result<()>{
+
+    let file = File::open(test_dir.join("msgs_float.jsonl"))?;
+
+    let lns : Lines<BufReader<File>> = BufReader::new(file).lines();
+
+    let mut state  = global_state::GlobalState::new(
+        test_const::BALANCELEVELS,
+        test_const::ORDERLEVELS,
+        test_const::ACCOUNTLEVELS,
+        test_const::NTXS,
+        test_const::VERBOSE,
+    );
+
+    println!("genesis root {}", state.root());
+
+    let mut place_order = PlaceOrder(PlaceOrderType::new());
+
+    for _ in 0..test_const::MAXACCOUNTNUM {
+        state.create_new_account(1);
+    }
+
+    for line in lns {
+        let msg = line.map(parse_msg)??;
+        match msg {
+            WrappedMessage::BALANCE(balance) => {
+                println!("balance {}", balance.change);
+                handle_deposit(&mut state, balance);
+            },
+            WrappedMessage::TRADE(trade) => {
+                println!("trade {}", trade.amount);
+                place_order.handle_trade(&mut state, trade);
+                
+            },
+            _ => {
+                //other msg is omitted
+            },
+        }
+    }
+
+    state.flush_with_nop();
+
+    Ok(())
+
+}
+
+fn export_circuit_and_testdata() {
+
+}
+
+fn test_all() -> Result<()> {
+    let circuit_repo = fs::canonicalize(PathBuf::from("../circuits")).expect("invalid circuits repo path");
+    let test_dir = circuit_repo.join("test").join("testdata");
+
+    replay_msgs(&test_dir)?;
+//    println!("genesis {} blocks")
+
+    export_circuit_and_testdata();
+/*
+  const { blocks, component } = replayMsgs();
+  console.log(`generate ${blocks.length} blocks`);
+
+  // check all the blocks forged are valid for the block circuit
+  // So we can ensure logics of matchengine VS GlobalState VS circuit are same!
+  const circuitDir = await exportCircuitAndTestData(blocks, component);
+*/
+
+    Ok(())
+}
+
+fn main() {
+    match test_all() {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("{:#?}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/circuit_test/messages.rs
+++ b/src/circuit_test/messages.rs
@@ -1,26 +1,25 @@
 use serde::{Deserialize, Serialize};
-use rust_decimal::prelude::Zero;
 use rust_decimal::Decimal;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum MarketRole {
     MAKER = 1,
     TAKER = 2,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum OrderSide {
     ASK,
     BID,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum OrderType {
     LIMIT,
     MARKET,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum OrderEventType {
     PUT = 1,
     UPDATE = 2,
@@ -60,10 +59,10 @@ pub struct OrderMessage {
 
 #[derive(Serialize, Deserialize)]
 pub struct VerboseOrderState {
-    price: Decimal,
-    amount: Decimal,
-    finished_base: Decimal,
-    finished_quote: Decimal,
+    pub price: Decimal,
+    pub amount: Decimal,
+    pub finished_base: Decimal,
+    pub finished_quote: Decimal,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -106,7 +105,7 @@ pub struct TradeMessage {
     pub state_after: VerboseTradeState,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct BalanceMessage {
     pub timestamp: f64,
     pub user_id: u32,

--- a/src/circuit_test/messages.rs
+++ b/src/circuit_test/messages.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
+#![allow(clippy::upper_case_acronyms)]
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum MarketRole {
@@ -55,7 +56,6 @@ pub struct OrderMessage {
     pub base: String,
     pub quote: String,
 }
-
 
 #[derive(Serialize, Deserialize)]
 pub struct VerboseOrderState {

--- a/src/circuit_test/messages.rs
+++ b/src/circuit_test/messages.rs
@@ -1,0 +1,118 @@
+use serde::{Deserialize, Serialize};
+use rust_decimal::prelude::Zero;
+use rust_decimal::Decimal;
+
+#[derive(Serialize, Deserialize)]
+pub enum MarketRole {
+    MAKER = 1,
+    TAKER = 2,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum OrderSide {
+    ASK,
+    BID,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum OrderType {
+    LIMIT,
+    MARKET,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum OrderEventType {
+    PUT = 1,
+    UPDATE = 2,
+    FINISH = 3,
+    EXPIRED = 4,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Order {
+    pub id: u64,
+    pub market: String,
+    #[serde(rename = "type")]
+    pub type_: OrderType, // enum
+    pub side: OrderSide,
+    pub user: u32,
+    pub create_time: f64,
+    pub update_time: f64,
+    pub price: Decimal,
+    pub amount: Decimal,
+    pub taker_fee: Decimal,
+    pub maker_fee: Decimal,
+    pub remain: Decimal,
+    pub frozen: Decimal,
+    pub finished_base: Decimal,
+    pub finished_quote: Decimal,
+    pub finished_fee: Decimal,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OrderMessage {
+    pub event: OrderEventType,
+    pub order: Order,
+    pub base: String,
+    pub quote: String,
+}
+
+
+#[derive(Serialize, Deserialize)]
+pub struct VerboseOrderState {
+    price: Decimal,
+    amount: Decimal,
+    finished_base: Decimal,
+    finished_quote: Decimal,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VerboseBalanceState {
+    pub bid_user_base: Decimal,
+    pub bid_user_quote: Decimal,
+    pub ask_user_base: Decimal,
+    pub ask_user_quote: Decimal,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VerboseTradeState {
+    // emit all the related state
+    pub ask_order_state: VerboseOrderState,
+    pub bid_order_state: VerboseOrderState,
+    pub balance: VerboseBalanceState,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TradeMessage {
+    pub id: u64,
+    pub timestamp: f64, // unix epoch timestamp,
+    pub market: String,
+    pub base: String,
+    pub quote: String,
+    pub price: Decimal,
+    pub amount: Decimal,
+    pub quote_amount: Decimal,
+
+    pub ask_user_id: u32,
+    pub ask_order_id: u64,
+    pub ask_role: MarketRole, // take/make
+    pub ask_fee: Decimal,
+
+    pub bid_user_id: u32,
+    pub bid_order_id: u64,
+    pub bid_role: MarketRole,
+    pub bid_fee: Decimal,
+    pub state_before: VerboseTradeState,
+    pub state_after: VerboseTradeState,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BalanceMessage {
+    pub timestamp: f64,
+    pub user_id: u32,
+    pub asset: String,
+    pub business: String,
+    pub change: Decimal,
+    pub balance: Decimal,
+    pub detail: String,
+}

--- a/src/circuit_test/mod.rs
+++ b/src/circuit_test/mod.rs
@@ -1,2 +1,3 @@
 pub mod binary_merkle_tree;
 pub mod types;
+pub mod messages;

--- a/src/circuit_test/mod.rs
+++ b/src/circuit_test/mod.rs
@@ -1,3 +1,3 @@
 pub mod binary_merkle_tree;
-pub mod types;
 pub mod messages;
+pub mod types;

--- a/src/circuit_test/types.rs
+++ b/src/circuit_test/types.rs
@@ -1,9 +1,12 @@
 //use serde_json::Value;
 use regex::Regex;
 
-use crate::state::types::Fr;
+use crate::state::types;
+pub use types::Fr;
 use ff::to_hex;
 use num_bigint::BigInt;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 
 #[derive(Default, Clone)]
 pub struct CircuitTestData {
@@ -30,4 +33,24 @@ pub fn format_circuit_name(s: &str) -> String {
 }
 pub fn field_to_string(elem: &Fr) -> String {
     BigInt::parse_bytes(to_hex(elem).as_bytes(), 16).unwrap().to_str_radix(10)
+}
+
+pub fn number_to_integer(num: &Decimal, prec: u32) -> Fr {
+    let prec_mul = Decimal::new(10, 0).powi(prec as u64);
+    let adjusted = num * prec_mul;
+    types::u64_to_fr(adjusted.floor().to_u64().unwrap())
+}
+
+pub use types::u32_to_fr;
+pub use types::u64_to_fr;
+
+
+#[cfg(test)]
+#[test]
+fn test_number_to_integer() {
+
+    let pi = Decimal::new(3141, 3);
+    let out = number_to_integer(&pi, 3);
+    assert_eq!("Fr(0x0000000000000000000000000000000000000000000000000000000000000c45)", out.to_string());
+
 }

--- a/src/circuit_test/types.rs
+++ b/src/circuit_test/types.rs
@@ -1,12 +1,17 @@
 //use serde_json::Value;
+#![feature(array_map)]
 use regex::Regex;
 
-use crate::state::types;
+use crate::state::{types, common};
 pub use types::Fr;
 use ff::to_hex;
 use num_bigint::BigInt;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use serde::Serialize;
+use serde::ser::SerializeSeq;
+
+use std::convert::TryFrom;
 
 #[derive(Default, Clone)]
 pub struct CircuitTestData {
@@ -53,4 +58,103 @@ fn test_number_to_integer() {
     let out = number_to_integer(&pi, 3);
     assert_eq!("Fr(0x0000000000000000000000000000000000000000000000000000000000000c45)", out.to_string());
 
+}
+
+pub struct FrStr (Fr);
+
+impl Serialize for FrStr {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(types::field_to_string(&self.0).as_str())
+    }
+}
+
+impl From<Fr> for FrStr {
+    fn from(origin : Fr) -> Self {
+        FrStr(origin)
+    }
+}
+
+pub struct MerkleLeafStr (FrStr);
+
+impl Serialize for MerkleLeafStr {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(1))?;
+        seq.serialize_element(&self.0)?;
+        seq.end()
+    }
+}
+
+//convert MerkleLeafType embedded in MerklePath 
+impl From<&[Fr;1]> for MerkleLeafStr {
+    fn from(origin : &[Fr;1]) -> Self {
+        MerkleLeafStr(FrStr(origin[0].clone()))
+    }
+}
+
+
+impl Serialize for common::TxType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i32(
+            match self {
+                common::TxType::DepositToNew => 1,
+                common::TxType::DepositToOld => 2,
+                common::TxType::Transfer => 3,
+                common::TxType::Withdraw => 4,
+                common::TxType::PlaceOrder => 5,
+                common::TxType::SpotTrade => 6,
+                common::TxType::Nop => 7,
+            }
+        )
+    }
+}
+
+type MerklePathStr = Vec<MerkleLeafStr>;
+
+//use derive could save many efforts for impling Serialize
+//TODO: carmel style except for three "elements" field
+#[derive(Serialize)]
+pub struct L2BlockSerde {
+    txs_type: Vec<common::TxType>,
+    encoded_txs: Vec<Vec<FrStr>>,
+    balance_path_elements: Vec<[MerklePathStr; 4]>,
+    order_path_elements: Vec<[MerklePathStr; 2]>,
+    account_path_elements: Vec<[MerklePathStr; 2]>,
+    order_roots: Vec<[FrStr; 2]>,
+    old_account_roots: Vec<FrStr>,
+    new_account_roots: Vec<FrStr>,    
+}
+
+//array::map is not stable
+fn array_map<U, T : Clone + Into<U>, const N: usize>(origin : [T; N]) -> [U; N] {
+    let mut collector : Vec<U> = Vec::new();
+    for i in &origin {
+        collector.push(i.clone().into());
+    }
+    TryFrom::try_from(collector).ok().unwrap()
+}
+
+fn from_merkle<const N: usize>(origin : [common::MerklePath; N]) -> [MerklePathStr; N] {
+    let mut collector : Vec<MerklePathStr> = Vec::new();
+    for i in &origin {
+        collector.push(i.iter().map(From::from).collect());
+    }
+    TryFrom::try_from(collector).ok().unwrap()
+}
+
+
+impl From<common::L2Block> for L2BlockSerde {
+    fn from(origin : common::L2Block) -> Self {
+        L2BlockSerde {
+            txs_type: origin.txs_type,
+            encoded_txs: origin.encoded_txs.into_iter().map(
+                |i|i.into_iter().map(From::from).collect()
+            ).collect(),
+            balance_path_elements: origin.balance_path_elements.into_iter().map(from_merkle).collect(),
+            order_path_elements: origin.order_path_elements.into_iter().map(from_merkle).collect(),
+            account_path_elements: origin.account_path_elements.into_iter().map(from_merkle).collect(),
+            order_roots: origin.order_roots.into_iter().map(array_map).collect(),
+            old_account_roots: origin.old_account_roots.into_iter().map(From::from).collect(),
+            new_account_roots: origin.new_account_roots.into_iter().map(From::from).collect(),
+        }        
+    }
 }

--- a/src/state/common.rs
+++ b/src/state/common.rs
@@ -1,6 +1,6 @@
 // from https://github1s.com/Fluidex/circuits/blob/HEAD/test/common.ts
 
-use super::merkle_tree::MerklePath;
+pub use super::merkle_tree::MerklePath;
 use super::types::{hash, shl, Fr};
 use ff::Field;
 

--- a/src/state/common.rs
+++ b/src/state/common.rs
@@ -4,7 +4,7 @@ use super::merkle_tree::MerklePath;
 use super::types::{hash, shl, Fr};
 use ff::Field;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Order {
     pub status: Fr,
     pub tokenbuy: Fr,
@@ -191,6 +191,7 @@ pub struct L2Block {
 }
 
 // TODO: remove previous_...
+#[derive(Debug)]
 pub struct PlaceOrderTx {
     pub account_id: u32,
     pub previous_token_id_sell: u32,
@@ -205,12 +206,14 @@ pub struct PlaceOrderTx {
     pub amount_buy: Fr,
 }
 
+#[derive(Debug)]
 pub struct DepositToOldTx {
     pub account_id: u32,
     pub token_id: u32,
     pub amount: Fr,
 }
 
+#[derive(Debug)]
 pub struct SpotTradeTx {
     pub order1_account_id: u32,
     pub order2_account_id: u32,

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -6,7 +6,7 @@ use super::types::{u32_to_fr, Fr};
 use ff::Field;
 use fnv::FnvHashMap;
 
-struct StateProof {
+pub struct StateProof {
     leaf: Fr,
     root: Fr,
     balance_root: Fr,
@@ -17,7 +17,7 @@ struct StateProof {
 
 // TODO: change to snake_case
 // TODO: too many unwrap here
-struct GlobalState {
+pub struct GlobalState {
     n_tx: usize,
     balance_levels: usize,
     order_levels: usize,

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -249,6 +249,13 @@ impl GlobalState {
             }
         }
     }
+    pub fn get_buffered_blocks(&self) -> &[L2Block] {
+        self.buffered_blocks.as_slice()
+    }
+    pub fn take_blocks(self) -> Vec<L2Block> {
+        self.buffered_blocks
+    }
+
     /*
     DepositToNew(tx: DepositToNewTx) {
       assert!(self.accounts.get(tx.account_id).eth_addr == 0n, "DepositToNew");
@@ -463,7 +470,7 @@ impl GlobalState {
     */
     pub fn place_order(&mut self, tx: PlaceOrderTx) -> u32 {
         if self.verbose {
-            //println!("PlaceOrder", tx, "operation id", self.buffered_txs.len());
+            println!("PlaceOrder {:#?} operation id {}", tx, self.buffered_txs.len());
         }
         // TODO: check order signature
         //assert!(self.accounts.get(tx.account_id).eth_addr != 0n, "PlaceOrder account: account_id" + tx.account_id);

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -38,6 +38,10 @@ pub fn shl(a: &Fr, x: u32) -> Fr {
 pub fn u32_to_fr(x: u32) -> Fr {
     Fr::from_str(&format!("{}", x)).unwrap()
 }
+pub fn u64_to_fr(x: u64) -> Fr {
+    Fr::from_repr(poseidon_rs::FrRepr::from(x)).unwrap()
+}
+
 pub fn field_to_bigint(elem: &Fr) -> BigInt {
     BigInt::parse_bytes(to_hex(elem).as_bytes(), 16).unwrap()
 }


### PR DESCRIPTION
Complete the requests required in #4

Some notes:

1. I think we read the messages according to the format defined in dingir-exchange, but it is crazy to depend on the whole project (too many useless crates would be involved). Currently I just grap the code from exchange project, have some trivial alters and put it under circuit_test/messages.rs

2. Some trivial changes (mostly some derive macros) are also applied on the types.rs in circuit_test

3. Not like its ts origin, digital calculations (like amount * price) are applied under Decimal structure and the final result is converted to integer base on its precise. This may bring a small discrepancies in digital data with its ts version.
