### PR TITLE
For better profiling on GlobalState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.cargo
 /target
 *orig

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ path = "src/bin/export_circuit_test.rs"
 
 [features]
 default = []
+bench_global_state = []

--- a/src/bin/global_state_test.rs
+++ b/src/bin/global_state_test.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Lines, Write};
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -49,17 +50,62 @@ fn parse_msg(line: String) -> Result<WrappedMessage> {
 type PlaceOrderType = HashMap<u32, (u32, u64)>;
 //index type?
 #[derive(Debug)]
-struct PlaceOrder(PlaceOrderType);
+struct PlaceOrder {
+    ordermapping: PlaceOrderType,
+    place_bench: f32,
+    spot_bench: f32,
+}
 
-impl AsRef<PlaceOrderType> for PlaceOrder {
-    fn as_ref(&self) -> &PlaceOrderType {
-        &self.0
+impl Deref for PlaceOrder {
+    type Target = PlaceOrderType;
+    fn deref(&self) -> &Self::Target {
+        &self.ordermapping
     }
 }
 
-impl AsMut<PlaceOrderType> for PlaceOrder {
-    fn as_mut(&mut self) -> &mut PlaceOrderType {
-        &mut self.0
+impl DerefMut for PlaceOrder {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ordermapping
+    }
+}
+
+impl Default for PlaceOrder {
+    fn default() -> Self {
+        PlaceOrder {
+            ordermapping: PlaceOrderType::new(),
+            place_bench: 0.0,
+            spot_bench: 0.0,
+        }
+    }
+}
+
+type PlaceAccountType = HashMap<u32, u32>;
+//index type?
+#[derive(Debug)]
+struct PlaceAccount {
+    accountmapping: PlaceAccountType,
+    balance_bench: f32,
+}
+
+impl Deref for PlaceAccount {
+    type Target = PlaceAccountType;
+    fn deref(&self) -> &Self::Target {
+        &self.accountmapping
+    }
+}
+
+impl DerefMut for PlaceAccount {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.accountmapping
+    }
+}
+
+impl Default for PlaceAccount {
+    fn default() -> Self {
+        PlaceAccount {
+            accountmapping: PlaceAccountType::new(),
+            balance_bench: 0.0,
+        }
     }
 }
 
@@ -87,6 +133,64 @@ mod test_const {
             0 | 1 => 6,
             _ => unreachable!(),
         }
+    }
+}
+
+//make ad-hoc transform in account_id
+impl PlaceAccount {
+    fn obtain_place_id(&mut self, state: &mut global_state::GlobalState, account_id: u32) -> u32 {
+        match self.get(&account_id) {
+            Some(pl_id) => *pl_id,
+            None => {
+                let uid = state.create_new_account(1);
+                self.insert(account_id, uid);
+                if test_const::VERBOSE {
+                    println!("global account id {} to user account id {}", uid, account_id);
+                }
+                uid
+            }
+        }
+    }
+
+    pub fn transform_trade(&mut self, state: &mut global_state::GlobalState, mut trade: messages::TradeMessage) -> messages::TradeMessage {
+        trade.ask_user_id = self.obtain_place_id(state, trade.ask_user_id);
+        trade.bid_user_id = self.obtain_place_id(state, trade.bid_user_id);
+
+        trade
+    }
+
+    pub fn handle_deposit(&mut self, state: &mut global_state::GlobalState, mut deposit: messages::BalanceMessage) {
+        //integrate the sanity check here ...
+        deposit.user_id = self.obtain_place_id(state, deposit.user_id);
+
+        assert!(!deposit.change.is_sign_negative(), "only support deposit now");
+
+        let token_id = test_const::token_id(&deposit.asset);
+
+        let balance_before = deposit.balance - deposit.change;
+        assert!(!balance_before.is_sign_negative(), "invalid balance {:?}", deposit);
+
+        let expected_balance_before = state.get_token_balance(deposit.user_id, token_id);
+        assert_eq!(
+            expected_balance_before,
+            types::number_to_integer(&balance_before, test_const::prec(token_id))
+        );
+
+        let timing = Instant::now();
+
+        state.deposit_to_old(common::DepositToOldTx {
+            token_id,
+            account_id: deposit.user_id,
+            amount: types::number_to_integer(&deposit.change, test_const::prec(token_id)),
+        });
+
+        self.balance_bench += timing.elapsed().as_secs_f32();
+    }
+
+    fn take_bench(&mut self) -> (f32, f32) {
+        let ret = (self.balance_bench, 0.0);
+        self.balance_bench = 0.0;
+        ret
     }
 }
 
@@ -273,6 +377,13 @@ fn assert_balance_state(
 }
 
 impl PlaceOrder {
+    fn take_bench(&mut self) -> (f32, f32) {
+        let ret = (self.place_bench, self.spot_bench);
+        self.place_bench = 0.0;
+        self.spot_bench = 0.0;
+        ret
+    }
+
     fn assert_order_state<'c>(&self, state: &global_state::GlobalState, ask_order_state: OrderState<'c>, bid_order_state: OrderState<'c>) {
         let ask_order_local = state
             .get_account_order_by_id(ask_order_state.account_id, ask_order_state.order_id)
@@ -332,13 +443,14 @@ impl PlaceOrder {
         put_states.sort();
 
         for order_state in put_states.into_iter() {
-            if !self.as_ref().contains_key(&order_state.order_id) {
+            if !self.contains_key(&order_state.order_id) {
                 //why the returning order id is u32?
                 // in fact the GlobalState should not expose "inner idx/pos" to caller
                 // we'd better handle this inside GlobalState later
+                let timing = Instant::now();
                 let new_order_pos = state.place_order(order_state.place_order_tx());
-                self.as_mut()
-                    .insert(order_state.order_id, (order_state.account_id, new_order_pos as u64));
+                self.place_bench += timing.elapsed().as_secs_f32();
+                self.insert(order_state.order_id, (order_state.account_id, new_order_pos as u64));
                 if test_const::VERBOSE {
                     println!(
                         "global order id {} to user order id ({},{})",
@@ -359,7 +471,9 @@ impl PlaceOrder {
         );
         self.assert_order_state(state, ask_order_state_before, bid_order_state_before);
 
+        let timing = Instant::now();
         state.spot_trade(self.trade_into_spot_tx(&trade));
+        self.spot_bench += timing.elapsed().as_secs_f32();
 
         assert_balance_state(
             &trade.state_after.balance,
@@ -369,31 +483,72 @@ impl PlaceOrder {
             id_pair,
         );
         self.assert_order_state(state, ask_order_state_after, bid_order_state_after);
-
-        println!("trade {} test done", trade.id);
     }
 }
 
-fn handle_deposit(state: &mut global_state::GlobalState, deposit: messages::BalanceMessage) {
-    //integrate the sanity check here ...
-    assert!(!deposit.change.is_sign_negative(), "only support deposit now");
+//if we use nightly build, we are able to use bench test ...
+fn bench_global_state(circuit_repo: &Path) -> Result<Vec<common::L2Block>> {
+    let test_dir = circuit_repo.join("test").join("testdata");
+    let file = File::open(test_dir.join("msgs_float.jsonl"))?;
 
-    let token_id = test_const::token_id(&deposit.asset);
+    let messages: Vec<WrappedMessage> = BufReader::new(file)
+        .lines()
+        .map(Result::unwrap)
+        .map(parse_msg)
+        .map(Result::unwrap)
+        .filter(|msg| matches!(msg, WrappedMessage::BALANCE(_) | WrappedMessage::TRADE(_)))
+        .collect();
 
-    let balance_before = deposit.balance - deposit.change;
-    assert!(!balance_before.is_sign_negative(), "invalid balance {:?}", deposit);
+    println!("prepare bench: {} records", messages.len());
 
-    let expected_balance_before = state.get_token_balance(deposit.user_id, token_id);
-    assert_eq!(
-        expected_balance_before,
-        types::number_to_integer(&balance_before, test_const::prec(token_id))
+    global_state::GlobalState::print_config();
+    //use custom states
+    let mut state = global_state::GlobalState::new(
+        10, //test_const::BALANCELEVELS,
+        10, //test_const::ORDERLEVELS,
+        10, //test_const::ACCOUNTLEVELS,
+        test_const::NTXS,
+        false,
     );
 
-    state.deposit_to_old(common::DepositToOldTx {
-        token_id,
-        account_id: deposit.user_id,
-        amount: types::number_to_integer(&deposit.change, test_const::prec(token_id)),
-    });
+    //amplify the records: in each iter we run records on a group of new accounts
+    let mut timing = Instant::now();
+    let mut place_order = PlaceOrder::default();
+    let mut place_account = PlaceAccount::default();
+    for i in 1..51 {
+        for msg in messages.iter() {
+            match msg {
+                WrappedMessage::BALANCE(balance) => {
+                    place_account.handle_deposit(&mut state, balance.clone());
+                }
+                WrappedMessage::TRADE(trade) => {
+                    let trade = place_account.transform_trade(&mut state, trade.clone());
+                    place_order.handle_trade(&mut state, trade);
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        place_order.clear();
+        place_account.clear();
+
+        if i % 10 == 0 {
+            let total = timing.elapsed().as_secs_f32();
+            let (balance_t, _) = place_account.take_bench();
+            let (plact_t, spot_t) = place_order.take_bench();
+            println!(
+                "{}th 10 iters in {:.5}s: balance {:.3}%, place {:.3}%, spot {:.3}%",
+                i / 10,
+                total,
+                balance_t * 100.0 / total,
+                plact_t * 100.0 / total,
+                spot_t * 100.0 / total
+            );
+            timing = Instant::now();
+        }
+    }
+
+    Ok(state.take_blocks())
 }
 
 fn replay_msgs(circuit_repo: &Path) -> Result<(Vec<common::L2Block>, types::CircuitSource)> {
@@ -412,20 +567,24 @@ fn replay_msgs(circuit_repo: &Path) -> Result<(Vec<common::L2Block>, types::Circ
 
     println!("genesis root {}", state.root());
 
-    let mut place_order = PlaceOrder(PlaceOrderType::new());
-
-    for _ in 0..test_const::MAXACCOUNTNUM {
-        state.create_new_account(1);
-    }
-
+    let mut place_order = PlaceOrder::default();
+    let mut place_account = PlaceAccount::default();
+    /*
+        for _ in 0..test_const::MAXACCOUNTNUM {
+            state.create_new_account(1);
+        }
+    */
     for line in lns {
         let msg = line.map(parse_msg)??;
         match msg {
             WrappedMessage::BALANCE(balance) => {
-                handle_deposit(&mut state, balance);
+                place_account.handle_deposit(&mut state, balance);
             }
             WrappedMessage::TRADE(trade) => {
+                let trade = place_account.transform_trade(&mut state, trade);
+                let trade_id = trade.id;
                 place_order.handle_trade(&mut state, trade);
+                println!("trade {} test done", trade_id);
             }
             _ => {
                 //other msg is omitted
@@ -500,6 +659,20 @@ fn export_circuit_and_testdata(
     Ok(circuit_dir)
 }
 
+fn test_bench() -> Result<()> {
+    let circuit_repo = fs::canonicalize(PathBuf::from("../circuits")).expect("invalid circuits repo path");
+
+    let timing = Instant::now();
+    let blocks = bench_global_state(&circuit_repo)?;
+    println!(
+        "bench for {} blocks (TPS: {})",
+        blocks.len(),
+        (test_const::NTXS * blocks.len()) as f32 / timing.elapsed().as_secs_f32()
+    );
+
+    Ok(())
+}
+
 fn test_all() -> Result<()> {
     let circuit_repo = fs::canonicalize(PathBuf::from("../circuits")).expect("invalid circuits repo path");
 
@@ -526,4 +699,6 @@ fn main() {
             std::process::exit(1);
         }
     }
+    #[cfg(feature = "bench_global_state")]
+    test_bench().expect("bench ok");
 }

--- a/src/circuit_test/messages.rs
+++ b/src/circuit_test/messages.rs
@@ -28,7 +28,7 @@ pub enum OrderEventType {
     EXPIRED = 4,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Order {
     pub id: u64,
     pub market: String,
@@ -49,7 +49,7 @@ pub struct Order {
     pub finished_fee: Decimal,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OrderMessage {
     pub event: OrderEventType,
     pub order: Order,
@@ -57,7 +57,7 @@ pub struct OrderMessage {
     pub quote: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VerboseOrderState {
     pub price: Decimal,
     pub amount: Decimal,
@@ -65,7 +65,7 @@ pub struct VerboseOrderState {
     pub finished_quote: Decimal,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VerboseBalanceState {
     pub bid_user_base: Decimal,
     pub bid_user_quote: Decimal,
@@ -73,7 +73,7 @@ pub struct VerboseBalanceState {
     pub ask_user_quote: Decimal,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VerboseTradeState {
     // emit all the related state
     pub ask_order_state: VerboseOrderState,
@@ -81,7 +81,7 @@ pub struct VerboseTradeState {
     pub balance: VerboseBalanceState,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TradeMessage {
     pub id: u64,
     pub timestamp: f64, // unix epoch timestamp,
@@ -105,7 +105,7 @@ pub struct TradeMessage {
     pub state_after: VerboseTradeState,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct BalanceMessage {
     pub timestamp: f64,
     pub user_id: u32,

--- a/src/state/global_state.rs
+++ b/src/state/global_state.rs
@@ -49,6 +49,10 @@ pub struct GlobalState {
 }
 
 impl GlobalState {
+    pub fn print_config() {
+        Tree::print_config();
+    }
+
     pub fn new(balance_levels: usize, order_levels: usize, account_levels: usize, n_tx: usize, verbose: bool) -> Self {
         let default_balance_root = empty_tree_root(balance_levels, Fr::zero());
         let default_order_leaf = Order::default().hash();

--- a/src/state/merkle_tree.rs
+++ b/src/state/merkle_tree.rs
@@ -1,6 +1,12 @@
 // https://github1s.com/Fluidex/circuits/blob/HEAD/helper.ts/binary_merkle_tree.ts
 
-use fnv::FnvHashMap;
+#[cfg(not(any(bench_merkle_stdmap, bench_merkle_treemap)))]
+use fnv::FnvHashMap as MerkleValueMapType;
+#[cfg(bench_merkle_treemap)]
+use std::collections::BTreeMap as MerkleValueMapType;
+#[cfg(bench_merkle_stdmap)]
+use std::collections::HashMap as MerkleValueMapType;
+
 use rayon::prelude::*;
 use std::iter;
 
@@ -10,7 +16,7 @@ use super::types::{hash, Fr};
 
 type LeafIndex = u32;
 type LeafType = Fr;
-type ValueMap = FnvHashMap<LeafIndex, LeafType>;
+type ValueMap = MerkleValueMapType<LeafIndex, LeafType>;
 
 pub struct MerkleProofN<const LENGTH: usize> {
     pub root: LeafType,
@@ -39,6 +45,10 @@ pub struct Tree {
 }
 
 impl Tree {
+    pub fn print_config() {
+        println!("merkletree valueMap type: {}", std::any::type_name::<ValueMap>())
+    }
+
     pub fn new(height: usize, default_leaf_node_value: LeafType) -> Self {
         // check overflow
         let _ = 2u32.checked_pow(height as u32).expect("tree depth error, overflow");

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -25,8 +25,20 @@ lazy_static! {
     //pub static ref POSEIDON_PARAMS: poseidon_rs::Constants = poseidon_rs::load_constants();
     pub static ref POSEIDON_HASHER: poseidon_rs::Poseidon = poseidon_rs::Poseidon::new();
 }
+#[cfg(not(bench_double_hash))]
 pub fn hash(inputs: &[Fr]) -> Fr {
     (&POSEIDON_HASHER).hash(inputs.to_vec()).unwrap()
+}
+
+#[cfg(bench_double_hash)]
+pub fn hash(inputs: &[Fr]) -> Fr {
+    let fr1 = (&POSEIDON_HASHER).hash(inputs.to_vec()).unwrap();
+    let fr2 = (&POSEIDON_HASHER).hash(inputs.to_vec()).unwrap();
+    if inputs.len() > 1 {
+        fr2
+    } else {
+        fr1
+    }
 }
 
 pub fn shl(a: &Fr, x: u32) -> Fr {


### PR DESCRIPTION
Add more profiling utilities in the global_state_test binary, and a additional profiling route, which would be run if `bench_global_state` feature is applied.

We also have prettier output like this:

``` text
prepare bench: 36 records
merkletree valueMap type: std::collections::hash::map::HashMap<u32, poseidon_rs::Fr, core::hash::BuildHasherDefault<fnv::FnvHasher>>
1th 10 iters in 1.78862s: balance 3.594%, place 24.385%, spot 71.084%
2th 10 iters in 1.74800s: balance 3.799%, place 23.908%, spot 71.268%
3th 10 iters in 1.70104s: balance 3.139%, place 23.599%, spot 72.389%
4th 10 iters in 1.68438s: balance 3.160%, place 24.089%, spot 71.896%
5th 10 iters in 1.66062s: balance 3.204%, place 24.106%, spot 71.817%
bench for 1775 blocks (TPS: 413.05704)

```

Also induce some cfg flags in the code for profiling different configures / verifying the hot spot

Notice we need to set RUSTFLAGS while compiling instead of using `cargo rustc` because the later only apply the cfg in final output (the binary) while these cfg flags must take effect in the building of library:

+ bench_merkle_treemap / bench_merkle_stdmap: 

   replace the fnvHashMap to common hashMap or btTreeMap

+ bench_double_hash

   double the hash operations in merkle tree, which is used for identify the hotspot (if hashing cost most, then doubling it should cut the TPS into half)

 With some profiling work we have some conclusion:

1. In benchmark we use 2-10-10-10 global state instead of the 2-2-7-2 in output, the later has nearly 80% faster (TPS 7xx vs 4xx)
2. In replymsgs, spot_trade use about 70% time, place_tx use 25%
3. No effect can be observed by changing the containers used in merkle tree from fnvHashMap to common hashMap or btTreeMap
4. If we apply bench_double_hash, i.e. do twice hashing in the hash call, the tps do being cut into half (from 4xx to 2xx tps). So the hashing is just the hot spot in replymsgs

